### PR TITLE
Changing to using jwt-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,63 +21,92 @@ s93_test_automation --product "PRODUCT" --endpoint "ENDPOINT" --api_key "API_KEY
 
 ### Arguments
 
-| Argument        | Short | Necessity | Description |
-| --------------- | :---: | :-------: | :- |
-| --product       | -p    | Required  | *(str)* Name of a product corresponding to a directory in [s93_test_automation/integration_tests](https://github.com/filetrust/aws-product-test-automation/tree/master/s93_test_automation/integration_tests).<br>e.g. `"rebuild"` |
-| --endpoint      | -e    | Required  | *(str)* API Gateway product endpoint url.<br> e.g. `"https://8oiyjy8w63.execute-api.us-west-2.amazonaws.com/Prod/api/Rebuild"` |
-| --api_key       | -a    | Required  | *(str)* An AWS API key that grants access to the endpoint specified as well as other Glasswall product endpoints, such as the presigned url generator.<br>e.g. `"a612ciXevo7FM9UKlkaj2D27s6u7Nieb6K2z9929d"` |
-| --test_files    | -t    | Optional  | **This functionality is currently disabled.**<br>*(str)* A directory containing external files to perform basic status code tests on. Defaults to `s93_test_automation/data/files/external`  |
-| --logging_level | -l    | Optional  | *(str)* The logging level of the Python logging module. Defaults to `INFO`. Valid values are: `NOTSET`,`DEBUG`,`INFO`,`WARNING`,`ERROR`,`CRITICAL` |
+| Argument         | Short | Necessity | Description |
+| ---------------- | :---: | :-------: | :- |
+| --product        | -p    | Required  | *(str)* Name of a product corresponding to a directory in [s93_test_automation/integration_tests](https://github.com/filetrust/aws-product-test-automation/tree/master/s93_test_automation/integration_tests).<br>e.g. `"rebuild"` |
+| --endpoint       | -e    | Required  | *(str)* API Gateway product endpoint url.<br> e.g. `"https://8oiyjy8w63.execute-api.us-west-2.amazonaws.com/Prod/api/Rebuild"` |
+| --api_key        | -a    | Required  | *(str)* An AWS API key that grants access to the endpoint specified as well as other Glasswall product endpoints, such as the presigned url generator.<br>e.g. `"a612ciXevo7FM9UKlkaj2D27s6u7Nieb6K2z9929d"` |
+| --jwt_token      | -j    | Required  | *(str)* An authorization token that grants access to the endpoint specified.<br>e.g. `""` |
+| --invalid_token  | -i    | Required  | *(str)* An invalid version of the jwt_token that will not grant access to the endpoint specified .<br>e.g. `""` |
+| --test_files     | -t    | Optional  | **This functionality is currently disabled.**<br>*(str)* A directory containing external files to perform basic status code tests on. Defaults to `s93_test_automation/data/files/external`  |
+| --logging_level  | -l    | Optional  | *(str)* The logging level of the Python logging module. Defaults to `INFO`. Valid values are: `NOTSET`,`DEBUG`,`INFO`,`WARNING`,`ERROR`,`CRITICAL` |
 
-### Example run (2020/05/14)
+### Example run (2020/07/03)
 <details>
 <summary>Click to expand</summary>
     
 ```cmd
-s93_test_automation --product "rebuild" --endpoint "***" --api_key "***"
+s93_test_automation --product "rebuild" --endpoint "***" --api_key "***" --jwt_token "***" --invalid_token "***"
 
 INFO:glasswall:Setting up Test_rebuild_base64
-test_post___bmp_32kb___returns_status_code_200_protected_file (test_rebuild_base64.Test_rebuild_base64) ... ok
-test_post___bmp_32kb_invalid_api_key___returns_status_code_403 (test_rebuild_base64.Test_rebuild_base64) ... ok
-test_post___bmp_over_6mb___returns_status_code_413 (test_rebuild_base64.Test_rebuild_base64) ... skipped '6 - 10mb edge case, results in status_code 500'   
-test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file (test_rebuild_base64.Test_rebuild_base64) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_disallow___returns_status_code_200_disallowed_json (test_rebuild_base64.Test_rebuild_base64) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_sanitise___returns_status_code_200_sanitised_file (test_rebuild_base64.Test_rebuild_base64) ... ok
+test_post___bmp_32kb___returns_status_code_200_protected_file (test_rebuild_base64.Test_rebuild_base64)
+1Test_File submit using base64 code & less than 6mb with valid jwt token is successful ... ok
+test_post___bmp_32kb_invalid_token___returns_status_code_403 (test_rebuild_base64.Test_rebuild_base64)
+3-Test_File submit using base64 code & less than 6mb with invalid jwt token is unsuccessful ... ok    
+test_post___bmp_over_6mb___returns_status_code_413 (test_rebuild_base64.Test_rebuild_base64)
+2-Test_Accurate error returned for a over 6mb file submit using base64 code with valid jwt token ... skipped '6 - 10mb edge case, results in status_code 500'
+test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file (test_rebuild_base64.Test_rebuild_base64)      
+4-Test_The default cmp policy is applied to submitted file using base64 code ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_disallow___returns_status_code_200_disallowed_json (test_rebuild_base64.Test_rebuild_base64)
+4-Test_The default cmp policy is applied to submitted file using base64 code ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_sanitise___returns_status_code_200_sanitised_file (test_rebuild_base64.Test_rebuild_base64)
+4-Test_The default cmp policy is applied to submitted file using base64 code ... ok
 test_post___external_files___returns_200_ok_for_all_files (test_rebuild_base64.Test_rebuild_base64) ... skipped ''
-test_post___jpeg_corrupt_10kb___returns_status_code_422 (test_rebuild_base64.Test_rebuild_base64) ... ok
-test_post___txt_1kb___returns_status_code_422 (test_rebuild_base64.Test_rebuild_base64) ... ok
-test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file (test_rebuild_base64.Test_rebuild_base64) ... ok
+test_post___jpeg_corrupt_10kb___returns_status_code_422 (test_rebuild_base64.Test_rebuild_base64)
+12-Test_upload of files with issues and or malware using base64 code with valid jwt token ... ok
+test_post___txt_1kb___returns_status_code_422 (test_rebuild_base64.Test_rebuild_base64)
+10-Test_unsupported file upload using base64 code & less than 6mb with valid jwt token is unsuccessful ... ok
+test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file (test_rebuild_base64.Test_rebuild_base64)
+12-Test_upload of files with issues and or malware using base64 code with valid jwt token ... ok
 INFO:glasswall:Setting up Test_rebuild_file
-test_post___bmp_32kb___returns_status_code_200_protected_file (test_rebuild_file.Test_rebuild_file) ... ok
-test_post___bmp_32kb_invalid_api_key___returns_status_code_403 (test_rebuild_file.Test_rebuild_file) ... ok
-test_post___bmp_over_6mb___returns_status_code_413 (test_rebuild_file.Test_rebuild_file) ... skipped '6 - 10mb edge case, results in status_code 500'
-test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file (test_rebuild_file.Test_rebuild_file) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_disallow___returns_status_code_200_disallowed_json (test_rebuild_file.Test_rebuild_file) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_sanitise___returns_status_code_200_sanitised_file (test_rebuild_file.Test_rebuild_file) ... ok
+test_post___bmp_32kb___returns_status_code_200_protected_file (test_rebuild_file.Test_rebuild_file)
+1Test_File submit using file endpoint & less than 6mb with valid jwt token is successful ... ok
+test_post___bmp_32kb_invalid_token___returns_status_code_403 (test_rebuild_file.Test_rebuild_file)
+3-Test_File submit using file endpoint & less than 6mb with invalid token is unsuccessful ... ok
+test_post___bmp_over_6mb___returns_status_code_413 (test_rebuild_file.Test_rebuild_file)
+2-Test_Accurate error returned for a over 6mb file submit using file endpoint with valid jwt token ... skipped '6 - 10mb edge case, results in status_code 500'
+test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file (test_rebuild_file.Test_rebuild_file)
+4-Test_The default cmp policy is applied to submitted file using file endpoint ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_disallow___returns_status_code_200_disallowed_json (test_rebuild_file.Test_rebuild_file)
+4-Test_The default cmp policy is applied to submitted file using file endpoint ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_sanitise___returns_status_code_200_sanitised_file (test_rebuild_file.Test_rebuild_file)
+4-Test_The default cmp policy is applied to submitted file using file endpoint ... ok
 test_post___external_files___returns_200_ok_for_all_files (test_rebuild_file.Test_rebuild_file) ... skipped ''
-test_post___jpeg_corrupt_10kb___returns_status_code_422 (test_rebuild_file.Test_rebuild_file) ... ok
-test_post___txt_1kb___returns_status_code_422 (test_rebuild_file.Test_rebuild_file) ... ok
-test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file (test_rebuild_file.Test_rebuild_file) ... ok
+test_post___jpeg_corrupt_10kb___returns_status_code_422 (test_rebuild_file.Test_rebuild_file)
+12-Test_upload of files with issues and or malware using file endpoint with valid jwt token ... ok
+test_post___txt_1kb___returns_status_code_422 (test_rebuild_file.Test_rebuild_file)
+10-Test_unsupported file upload using file endpoint & less than 6mb with valid jwt token is unsuccessful ... ok
+test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file (test_rebuild_file.Test_rebuild_file)
+12-Test_upload of files with issues and or malware using file endpoint with valid jwt token ... ok
 INFO:glasswall:Setting up Test_rebuild_url
 INFO:glasswall:Generating presigned urls...
-INFO:glasswall:File uploaded to: customer-uploaded-files/b0fd56c0-f3f1-42e1-b4d6-23133f15092e/15-05-2020 12:42:47/bmp_32kb.bmp
-INFO:glasswall:File uploaded to: customer-uploaded-files/1a7447c0-7ee8-4e4d-b39d-0b18f9898ed1/15-05-2020 12:42:49/bmp_5.93mb.bmp
-INFO:glasswall:File uploaded to: customer-uploaded-files/9a4c6962-032d-4e24-aef5-b50bf9acba21/15-05-2020 12:42:56/bmp_6.12mb.bmp
-INFO:glasswall:File uploaded to: customer-uploaded-files/3ad4c097-6acc-49ac-8c8a-6745fc40cf65/15-05-2020 12:43:02/txt_1kb.txt
-INFO:glasswall:File uploaded to: customer-uploaded-files/eabbacd6-fb0e-4af6-9e75-64283e95dbac/15-05-2020 12:43:02/doc_embedded_images_12kb.docx
-INFO:glasswall:File uploaded to: customer-uploaded-files/75ccbd10-a5f4-4a46-8ef5-24143cd73af7/15-05-2020 12:43:03/CalcTest.xls
-test_post___bmp_32kb___returns_status_code_200_protected_file (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___bmp_32kb_invalid_api_key___returns_status_code_403 (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___bmp_32kb_no_api_key___returns_status_code_403 (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_disallow___returns_status_code_200_disallowed_json (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___doc_embedded_images_12kb_content_management_policy_sanitise___returns_status_code_200_sanitised_file (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___jpeg_corrupt_10kb___returns_status_code_422 (test_rebuild_url.Test_rebuild_url) ... skipped 'waiting for update to the presigned url lambda to allow files with no extension'
-test_post___txt_1kb___returns_status_code_422 (test_rebuild_url.Test_rebuild_url) ... ok
-test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file (test_rebuild_url.Test_rebuild_url) ... ok
+INFO:glasswall:File uploaded to: customer-uploaded-files/990f5e12-d1af-4117-9765-840f22443cd4/03-07-2020 11:17:49/bmp_32kb.bmp
+INFO:glasswall:File uploaded to: customer-uploaded-files/70865cea-1c18-4058-84de-5f5c8ed0e673/03-07-2020 11:17:50/bmp_5.93mb.bmp
+INFO:glasswall:File uploaded to: customer-uploaded-files/1c782b52-9040-4966-b104-cb05ff43994a/03-07-2020 11:17:51/bmp_6.12mb.bmp
+INFO:glasswall:File uploaded to: customer-uploaded-files/0fefdf28-1665-4ffe-bd57-a3a4b5e9c503/03-07-2020 11:17:52/txt_1kb.txt
+INFO:glasswall:File uploaded to: customer-uploaded-files/3f054895-d786-4620-9219-24ba33af7385/03-07-2020 11:17:52/doc_embedded_images_12kb.docx
+INFO:glasswall:File uploaded to: customer-uploaded-files/1f71ddb5-cec8-4854-8780-1e3b0ebb4fcc/03-07-2020 11:17:52/CalcTest.xls
+test_post___bmp_32kb___returns_status_code_200_protected_file (test_rebuild_url.Test_rebuild_url)
+5-Test_File submit using pre-signed url with valid jwt token is successful ... ok
+test_post___bmp_32kb_invalid_token___returns_status_code_403 (test_rebuild_url.Test_rebuild_url)
+6b-Test_File submit using pre-signed url with invalid token is unsuccessful ... ok
+test_post___bmp_32kb_no_jwt_token___returns_status_code_403 (test_rebuild_url.Test_rebuild_url)
+6a-Test_File submit using pre-signed url with no jwt token is unsuccessful ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file (test_rebuild_url.Test_rebuild_url)
+7a-Test_The default cmp policy is applied to submitted file using pre-signed url ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_disallow___returns_status_code_200_disallowed_json (test_rebuild_url.Test_rebuild_url)
+7c-Test_The default cmp policy is applied to submitted file using pre-signed url ... ok
+test_post___doc_embedded_images_12kb_content_management_policy_sanitise___returns_status_code_200_sanitised_file (test_rebuild_url.Test_rebuild_url)
+7b-Test_The default cmp policy is applied to submitted file using pre-signed url ... ok
+test_post___jpeg_corrupt_10kb___returns_status_code_422 (test_rebuild_url.Test_rebuild_url)
+11b-Test_upload of files with issues and or malware using presigned with valid jwt token ... skipped 'waiting for update to the presigned url lambda to allow files with no extension'
+test_post___txt_1kb___returns_status_code_422 (test_rebuild_url.Test_rebuild_url)
+9-Test_unsupported file upload using pre-signed url with valid jwt token is unsuccessful ... ok
+test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file (test_rebuild_url.Test_rebuild_url)
+11a-Test_upload of files with issues and or malware using presigned with valid jwt token ... ok
 
 ----------------------------------------------------------------------
-Ran 29 tests in 34.634s
+Ran 29 tests in 8.377s
 
 OK (skipped=5)
 ```

--- a/s93_test_automation/__main__.py
+++ b/s93_test_automation/__main__.py
@@ -28,9 +28,24 @@ def get_command_line_args():
     parser.add_argument(
         "--api_key", "-a",
         dest="api_key",
-        help="API key to access endpoint.",
+        help="API key to access endpoint for s3 Bucket.",
         type=str,
         required=True
+    )
+    parser.add_argument(
+        "--jwt_token", "-j",
+        dest="jwt_token",
+        help="authorisation token to access endpoint.",
+        type=str,
+        required=True
+    )
+    parser.add_argument(
+        "--invalid_token","-i",
+        dest="invalid_token",
+        help="invalid token that cannot acess endpoint.",
+        type=str,
+        required=True
+
     )
     parser.add_argument(
         "--test_files", "-t",
@@ -57,6 +72,8 @@ def set_environment_variables(args):
     os.environ["endpoint"]      = args.endpoint
     os.environ["api_key"]       = args.api_key
     os.environ["test_files"]    = args.test_files
+    os.environ["jwt_token"]     = args.jwt_token
+    os.environ["invalid_token"] = args.invalid_token
 
 
 def set_logging_level(level):

--- a/s93_test_automation/integration_tests/rebuild/test_rebuild_base64.py
+++ b/s93_test_automation/integration_tests/rebuild/test_rebuild_base64.py
@@ -15,8 +15,8 @@ class Test_rebuild_base64(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         log.info(f"Setting up {cls.__name__}")
-        cls.endpoint                    = f"{os.environ['endpoint']}/base64"
-        cls.api_key                     = os.environ["api_key"]
+        cls.endpoint                    = f"{os.environ['endpoint']}/api/rebuild/base64"
+        cls.jwt_token                   = os.environ["jwt_token"]
 
         cls.bmp_32kb                    = os.path.join(_ROOT, "data", "files", "under_6mb", "bmp", "bmp_32kb.bmp")
         cls.bmp_under_6mb               = os.path.join(_ROOT, "data", "files", "under_6mb", "bmp", "bmp_5.93mb.bmp")
@@ -58,7 +58,7 @@ class Test_rebuild_base64(unittest.TestCase):
                 },
                 headers={
                     "Content-Type": "application/json",
-                    "x-api-key": self.api_key
+                    "Authorization": self.jwt_token
                 }
             )
 
@@ -70,9 +70,9 @@ class Test_rebuild_base64(unittest.TestCase):
 
     def test_post___bmp_32kb___returns_status_code_200_protected_file(self):
         """
-        1Test_File submit using base64 code & less than 6mb with valid x-api key is successful
+        1Test_File submit using base64 code & less than 6mb with valid jwt token is successful
         Steps:
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected:
         The response is returned with the processed file & success code 200
         """
@@ -88,7 +88,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -107,9 +107,9 @@ class Test_rebuild_base64(unittest.TestCase):
     @unittest.skip("6 - 10mb edge case, results in status_code 500")
     def test_post___bmp_over_6mb___returns_status_code_413(self):
         """
-        2-Test_Accurate error returned for a over 6mb file submit using base64 code with valid x-api key
+        2-Test_Accurate error returned for a over 6mb file submit using base64 code with valid jwt token
         Steps:
-            Post file over 6mb payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post file over 6mb payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected:
         The response message '' is returned with error code 400
         """
@@ -125,7 +125,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -135,11 +135,11 @@ class Test_rebuild_base64(unittest.TestCase):
             HTTPStatus.REQUEST_ENTITY_TOO_LARGE
         )
 
-    def test_post___bmp_32kb_invalid_api_key___returns_status_code_403(self):
+    def test_post___bmp_32kb_invalid_token___returns_status_code_403(self):
         """
-        3-Test_File submit using base64 code & less than 6mb with invalid x-api key is unsuccessful
+        3-Test_File submit using base64 code & less than 6mb with invalid jwt token is unsuccessful
         Steps:
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with invalid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with invalid jwt token
         Expected:
         return error code 401
         """
@@ -155,14 +155,14 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": ""
+                "Authorization": ""
             }
         )
 
         # Status code should be 403, forbidden
         self.assertEqual(
             response.status_code,
-            HTTPStatus.FORBIDDEN
+            HTTPStatus.UNAUTHORIZED
         )
 
     def test_post___doc_embedded_images_12kb_content_management_policy_allow___returns_status_code_200_identical_file(self):
@@ -170,7 +170,7 @@ class Test_rebuild_base64(unittest.TestCase):
         4-Test_The default cmp policy is applied to submitted file using base64 code
         Steps:
             Set cmp policy for file type as 'cmptype'
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected:
         The response is returned with success code '200'
             0) If cmpType is 'Allow', Then the file is allowed & the original file is returned
@@ -230,7 +230,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -253,7 +253,7 @@ class Test_rebuild_base64(unittest.TestCase):
         4-Test_The default cmp policy is applied to submitted file using base64 code
         Steps:
             Set cmp policy for file type as 'cmptype'
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected:
         The response is returned with success code '200'
             0) If cmpType is 'Allow', Then the file is allowed & the original file is returned
@@ -284,7 +284,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -306,7 +306,7 @@ class Test_rebuild_base64(unittest.TestCase):
         4-Test_The default cmp policy is applied to submitted file using base64 code
         Steps:
             Set cmp policy for file type as 'cmptype'
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected:
         The response is returned with success code '200'
             0) If cmpType is 'Allow', Then the file is allowed & the original file is returned
@@ -330,7 +330,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -351,9 +351,9 @@ class Test_rebuild_base64(unittest.TestCase):
 
     def test_post___txt_1kb___returns_status_code_422(self):
         """
-        10-Test_unsupported file upload using base64 code & less than 6mb with valid x-api key is unsuccessful
+        10-Test_unsupported file upload using base64 code & less than 6mb with valid jwt token is unsuccessful
         Execution Steps:
-            Post a unsupported file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post a unsupported file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected Results:
         The response message 'Unprocessable Entity' is returned with error code '422'
         """
@@ -369,7 +369,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -381,11 +381,11 @@ class Test_rebuild_base64(unittest.TestCase):
 
     def test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file(self):
         """
-        12-Test_upload of files with issues and or malware using base64 code with valid x-api key 
+        12-Test_upload of files with issues and or malware using base64 code with valid jwt token 
         Execution Steps:
-            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
-            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
-            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
+            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
+            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected Results:
         The response message returned for file containing malware is:'OK' with success code '200'
         The response message returned for file containing structural issues is: 'Unprocessable Entity' with error code '422'
@@ -403,7 +403,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 
@@ -422,11 +422,11 @@ class Test_rebuild_base64(unittest.TestCase):
 
     def test_post___jpeg_corrupt_10kb___returns_status_code_422(self):
         """
-        12-Test_upload of files with issues and or malware using base64 code with valid x-api key 
+        12-Test_upload of files with issues and or malware using base64 code with valid jwt token 
         Execution Steps:
-            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
-            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
-            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid x-api key
+            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
+            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
+            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/base64' with valid jwt token
         Expected Results:
         The response message returned for file containing malware is:'OK' with success code '200'
         The response message returned for file containing structural issues is: 'Unprocessable Entity' with error code '422'
@@ -444,7 +444,7 @@ class Test_rebuild_base64(unittest.TestCase):
             },
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": self.api_key
+                "Authorization": self.jwt_token
             }
         )
 

--- a/s93_test_automation/integration_tests/rebuild/test_rebuild_file.py
+++ b/s93_test_automation/integration_tests/rebuild/test_rebuild_file.py
@@ -16,8 +16,9 @@ class Test_rebuild_file(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         log.info(f"Setting up {cls.__name__}")
-        cls.endpoint                    = f"{os.environ['endpoint']}/file"
-        cls.api_key                     = os.environ["api_key"]
+        cls.endpoint                    = f"{os.environ['endpoint']}/api/rebuild/file"
+        cls.jwt_token                   = os.environ["jwt_token"]
+        cls.invalid_token               = os.environ["invalid_token"]
 
         cls.bmp_32kb                    = os.path.join(_ROOT, "data", "files", "under_6mb", "bmp", "bmp_32kb.bmp")
         cls.bmp_under_6mb               = os.path.join(_ROOT, "data", "files", "under_6mb", "bmp", "bmp_5.93mb.bmp")
@@ -57,7 +58,7 @@ class Test_rebuild_file(unittest.TestCase):
                     files=[("file", test_file)],
                     headers={
                         "accept": "application/octet-stream",
-                        "x-api-key": self.api_key,
+                        "Authorization": self.jwt_token,
                     },
                 )
 
@@ -69,9 +70,9 @@ class Test_rebuild_file(unittest.TestCase):
 
     def test_post___bmp_32kb___returns_status_code_200_protected_file(self):
         """
-        1Test_File submit using file endpoint & less than 6mb with valid x-api key is successful
+        1Test_File submit using file endpoint & less than 6mb with valid jwt token is successful
         Steps:
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected:
         The response is returned with the processed file & success code 200
         """
@@ -83,7 +84,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 }
             )
 
@@ -102,9 +103,9 @@ class Test_rebuild_file(unittest.TestCase):
     @unittest.skip("6 - 10mb edge case, results in status_code 500")
     def test_post___bmp_over_6mb___returns_status_code_413(self):
         """
-        2-Test_Accurate error returned for a over 6mb file submit using file endpoint with valid x-api key
+        2-Test_Accurate error returned for a over 6mb file submit using file endpoint with valid jwt token
         Steps:
-            Post file over 6mb payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post file over 6mb payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected:
         The response message '' is returned with error code 400
         """
@@ -116,7 +117,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 }
             )
 
@@ -126,11 +127,11 @@ class Test_rebuild_file(unittest.TestCase):
             HTTPStatus.REQUEST_ENTITY_TOO_LARGE
         )
 
-    def test_post___bmp_32kb_invalid_api_key___returns_status_code_403(self):
+    def test_post___bmp_32kb_invalid_token___returns_status_code_403(self):
         """
-        3-Test_File submit using file endpoint & less than 6mb with invalid x-api key is unsuccessful
+        3-Test_File submit using file endpoint & less than 6mb with invalid token is unsuccessful
         Steps:
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with invalid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with invalid token
         Expected:
         return error code 401
         """
@@ -142,7 +143,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key + "abcdef",
+                    "Authorization": self.invalid_token,
                 }
             )
 
@@ -157,7 +158,7 @@ class Test_rebuild_file(unittest.TestCase):
         4-Test_The default cmp policy is applied to submitted file using file endpoint
         Steps:
             Set cmp policy for file type as 'cmptype'
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected:
         The response is returned with success code '200'
             0) If cmpType is 'Allow', Then the file is allowed & the original file is returned
@@ -215,7 +216,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 },
             )
 
@@ -237,7 +238,7 @@ class Test_rebuild_file(unittest.TestCase):
         4-Test_The default cmp policy is applied to submitted file using file endpoint
         Steps:
             Set cmp policy for file type as 'cmptype'
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected:
         The response is returned with success code '200'
             0) If cmpType is 'Allow', Then the file is allowed & the original file is returned
@@ -266,7 +267,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 },
             )
 
@@ -287,7 +288,7 @@ class Test_rebuild_file(unittest.TestCase):
         4-Test_The default cmp policy is applied to submitted file using file endpoint
         Steps:
             Set cmp policy for file type as 'cmptype'
-            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected:
         The response is returned with success code '200'
             0) If cmpType is 'Allow', Then the file is allowed & the original file is returned
@@ -309,7 +310,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 },
             )
 
@@ -330,9 +331,9 @@ class Test_rebuild_file(unittest.TestCase):
 
     def test_post___txt_1kb___returns_status_code_422(self):
         """
-        10-Test_unsupported file upload using file endpoint & less than 6mb with valid x-api key is unsuccessful
+        10-Test_unsupported file upload using file endpoint & less than 6mb with valid jwt token is unsuccessful
         Execution Steps:
-            Post a unsupported file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post a unsupported file payload request to endpoint: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected Results:
         The response message 'Unprocessable Entity' is returned with error code '422'
         """
@@ -344,7 +345,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 },
             )
 
@@ -356,11 +357,11 @@ class Test_rebuild_file(unittest.TestCase):
 
     def test_post___xls_malware_macro_48kb___returns_status_code_200_sanitised_file(self):
         """
-        12-Test_upload of files with issues and or malware using file endpoint with valid x-api key
+        12-Test_upload of files with issues and or malware using file endpoint with valid jwt token
         Execution Steps:
-            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
-            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
-            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
+            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
+            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected Results:
         The response message returned for file containing malware is:'OK' with success code '200'
         The response message returned for file containing structural issues is: 'Unprocessable Entity' with error code '422'
@@ -381,7 +382,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 },
             )
 
@@ -399,11 +400,11 @@ class Test_rebuild_file(unittest.TestCase):
 
     def test_post___jpeg_corrupt_10kb___returns_status_code_422(self):
         """
-        12-Test_upload of files with issues and or malware using file endpoint with valid x-api key
+        12-Test_upload of files with issues and or malware using file endpoint with valid jwt token
         Execution Steps:
-            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
-            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
-            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid x-api key
+            Post a payload request with file containing malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
+            Post a payload request with file containing structural issues to url: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
+            Post a payload request with file containing issues and malware to url: '[API GATEWAY URL]/api/Rebuild/file' with valid jwt token
         Expected Results:
         The response message returned for file containing malware is:'OK' with success code '200'
         The response message returned for file containing structural issues is: 'Unprocessable Entity' with error code '422'
@@ -417,7 +418,7 @@ class Test_rebuild_file(unittest.TestCase):
                 files=[("file", test_file)],
                 headers={
                     "accept": "application/octet-stream",
-                    "x-api-key": self.api_key,
+                    "Authorization": self.jwt_token,
                 },
             )
 


### PR DESCRIPTION
Updating tests to stop using x-api-key and start using jwt token.
x-api-key kept to use for s3 upload.
Added two new arguments, jwt_token and invalid_token to use during tests